### PR TITLE
Fix mobile layout and spacing issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
             <div class="map-container">
                 <iframe
                     src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2891.983002385495!2d23.54731827655343!3d43.21307827112747!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x40ab18e572bb6797%3A0xc2ff2bc70d0a5570!2z0KfQtdGA0LXQv9C10LrRgiDQmtCw0YDQtdGB0YLRgNC-0LLQsCAi0KHQu9Cw0YDQvtGA0LDQvdC40Y8i!5e0!3m2!1sbg!2sbg!4v1719065095560!5m2!1sbg!2sbg"
-                    width="400" height="300" style="border:0; margin-top: 10px;" allowfullscreen="" loading="lazy"
+                    style="border:0;" allowfullscreen="" loading="lazy"
                     referrerpolicy="no-referrer-when-downgrade">
                 </iframe>
             </div>

--- a/style.css
+++ b/style.css
@@ -87,8 +87,8 @@ footer {
 }
 
 .map-container {
-    width: 400px;
-    height: 300px;
+    width: min(400px, 100%);
+    aspect-ratio: 4 / 3;
     margin: 10px auto;
 }
 
@@ -147,11 +147,13 @@ svg {
 
 .main-right {
     display: flex;
-    height: 100vh;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 16px 0;
 }
 
 .main-right>nav {
-    flex: 1;
+    flex: 0 0 auto;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -159,7 +161,6 @@ svg {
 
 .main-right [aria-label="Primary"] {
     width: 100%;
-    height: 100vh;
     text-align: center;
 }
 
@@ -238,14 +239,12 @@ svg {
     }
 
     .main-right {
-        display: flex;
+        display: block;
+        padding: 12px 0;
     }
 
     .main-right>nav {
-        flex: 1;
-        display: flex;
-        justify-content: center;
-        align-items: center;
+        display: block;
     }
 
     .main-right .primary-links {
@@ -292,79 +291,56 @@ svg {
         /* keep full image */
         object-fit: contain;
         /* no cropping */
+    }
 
-        footer {
-            font-size: 0.9rem;
-            padding: 15px;
-        }
+    footer {
+        font-size: 0.9rem;
+        padding: 15px;
+    }
 
-        .map-container {
-            width: 100%;
-            /* full width of parent */
-            height: auto;
-            /* keep aspect ratio with padding trick */
-            position: relative;
-            padding-bottom: 75%;
-            /* 300 / 400 = 0.75 aspect ratio */
-            height: 0;
-            /* required for aspect ratio trick */
-        }
+    .language-switcher {
+        flex-wrap: wrap;
+        justify-content: center;
+    }
 
-        .map-container iframe {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-        }
+    .language-switcher button {
+        width: 100px;
+        justify-content: center;
+    }
 
-        .language-switcher {
-            flex-wrap: wrap;
-            justify-content: center;
-        }
+    .primary-links a {
+        width: 100%;
+        max-width: 320px;
+        min-height: 48px;
+        font-size: 1.1rem;
+    }
 
-        .language-switcher button {
-            width: 100px;
-            justify-content: center;
-        }
+    .main-right {
+        display: block;
+        padding: 12px 0;
+    }
 
-        .primary-links a {
-            width: 100%;
-            max-width: 320px;
-            min-height: 48px;
-            font-size: 1.1rem;
-        }
+    .main-right>nav {
+        display: block;
+        padding: 8px 0;
+        background: transparent;
+        border: 0;
+    }
 
-        .main-right {
-            display: block;
-        }
+    /* Tighter list spacing */
+    .main-right .primary-links {
+        gap: 8px;
+        align-items: center;
+        margin: 0;
+        padding: 0;
+    }
 
-        .main-right>nav {
-            display: block;
-            padding: 8px 0;
-            background: transparent;
-            border: 0;
-        }
-
-        /* Tighter list spacing */
-        .main-right .primary-links {
-            gap: 8px;
-            /* was 16–20px */
-            align-items: center;
-            /* keep centered horizontally */
-            margin: 0;
-            padding: 0;
-        }
-
-        /* Smaller buttons/links */
-        .primary-links a {
-            min-height: 40px;
-            /* was 48–56px */
-            padding: 4px 10px;
-            /* was larger */
-            font-size: 1rem;
-            /* slightly smaller */
-             width: min(100%, 320px); max-width: 100%;
-        }
+    /* Smaller buttons/links */
+    .primary-links a {
+        min-height: 40px;
+        padding: 4px 10px;
+        font-size: 1rem;
+        width: min(100%, 320px);
+        max-width: 100%;
     }
 }

--- a/style.css
+++ b/style.css
@@ -229,13 +229,13 @@ svg {
     }
 
     .main-left {
-        height: auto;
+        height: 50vh;
     }
 
     .main-left img {
         width: 100%;
-        height: auto;
-        object-fit: contain;
+        height: 100%;
+        object-fit: cover;
     }
 
     .main-right {
@@ -282,15 +282,13 @@ svg {
     }
 
     .main-left {
-        height: auto;
+        height: 45vh;
     }
 
     .main-left img {
         width: 100%;
-        height: auto;
-        /* keep full image */
-        object-fit: contain;
-        /* no cropping */
+        height: 100%;
+        object-fit: cover;
     }
 
     footer {

--- a/style.css
+++ b/style.css
@@ -87,7 +87,7 @@ footer {
 }
 
 .map-container {
-    width: min(400px, 100%);
+    width: clamp(240px, 60vw, 400px);
     aspect-ratio: 4 / 3;
     margin: 10px auto;
 }


### PR DESCRIPTION
Fix mobile layout overflow, footer fit, and `main-right` spacing by making the map responsive, adjusting `main-right` padding, and correcting media query syntax.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb35fa3e-7b99-47d0-9173-41baa76be946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb35fa3e-7b99-47d0-9173-41baa76be946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

