### PR TITLE
Debug hamburger menu translation in dishes and drinks

### DIFF
--- a/dishes.html
+++ b/dishes.html
@@ -1197,7 +1197,7 @@
 
             list.insertAdjacentHTML('afterbegin', `
             <li><a href="index.html">← Home</a></li>
-            <li><a href="menu.html">Menu</a></li>
+            <li><a href="menu.html" data-i18n="menu">Menu</a></li>
             <li><hr></li>
             `);
 
@@ -1210,7 +1210,18 @@
                 const li = document.createElement('li');
                 const a = document.createElement('a');
                 a.href = `#${section.id}`;
-                a.textContent = title.textContent.trim();
+                const key = title.getAttribute('data-i18n');
+                if (key) {
+                    a.setAttribute('data-i18n', key);
+                    const savedLang = localStorage.getItem('language') || 'bg';
+                    if (typeof translations !== 'undefined' && translations[savedLang] && translations[savedLang][key]) {
+                        a.textContent = translations[savedLang][key];
+                    } else {
+                        a.textContent = title.textContent.trim();
+                    }
+                } else {
+                    a.textContent = title.textContent.trim();
+                }
                 a.addEventListener('click', () => {
                     closeMenu();
                 });

--- a/drinks.html
+++ b/drinks.html
@@ -769,7 +769,7 @@
 
             list.insertAdjacentHTML('afterbegin', `
             <li><a href="index.html">← Home</a></li>
-            <li><a href="menu.html">Menu</a></li>
+            <li><a href="menu.html" data-i18n="menu">Menu</a></li>
             <li><hr></li>
             `);
 
@@ -782,7 +782,18 @@
                 const li = document.createElement('li');
                 const a = document.createElement('a');
                 a.href = `#${section.id}`;
-                a.textContent = title.textContent.trim();
+                const key = title.getAttribute('data-i18n');
+                if (key) {
+                    a.setAttribute('data-i18n', key);
+                    const savedLang = localStorage.getItem('language') || 'bg';
+                    if (typeof translations !== 'undefined' && translations[savedLang] && translations[savedLang][key]) {
+                        a.textContent = translations[savedLang][key];
+                    } else {
+                        a.textContent = title.textContent.trim();
+                    }
+                } else {
+                    a.textContent = title.textContent.trim();
+                }
                 a.addEventListener('click', () => {
                     closeMenu();
                 });


### PR DESCRIPTION
Update hamburger menu items in `dishes.html` and `drinks.html` to translate correctly.

The hamburger menu items were not translating because they were generated from static H3 text (Bulgarian) before translation scripts ran and lacked `data-i18n` attributes. This change ensures dynamic links use translation keys and are initialized with the saved language.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0fa63e1-346f-4a72-8dfc-0581274831e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f0fa63e1-346f-4a72-8dfc-0581274831e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

